### PR TITLE
Feat/home devices

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
-
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/bluetooth_chat/BluetoothDevicesActivity.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/BluetoothDevicesActivity.kt
@@ -117,7 +117,7 @@ fun BluetoothDevicesScreen(devices: List<String>, modifier: Modifier = Modifier)
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(64.dp)
-                        .clickable { /* Dummy click handler */ },
+                        .clickable {},
                     shape = MaterialTheme.shapes.medium,
                     tonalElevation = 2.dp,
                     color = MaterialTheme.colorScheme.surfaceVariant

--- a/app/src/main/java/com/example/bluetooth_chat/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/MainActivity.kt
@@ -1,55 +1,85 @@
 package com.example.bluetooth_chat
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.example.bluetooth_chat.ui.components.Navbar
 import com.example.bluetooth_chat.ui.components.BottomNavbar
+import com.example.bluetooth_chat.ui.components.Navbar
 import com.example.bluetooth_chat.ui.theme.BluetoothchatTheme
-import com.example.bluetooth_chat.ui.theme.HomeScreen
+import com.example.bluetooth_chat.ui.components.HomeScreen
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import com.example.bluetooth_chat.ui.components.EnableBluetoothScreen
+import com.example.bluetooth_chat.bluetooth.BluetoothChecker
 
 class MainActivity : ComponentActivity() {
+
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge()
+
+        requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { isGranted: Boolean ->
+            if (!isGranted) {
+                Toast.makeText(this, "Bluetooth permission is required", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        if (!hasBluetoothConnectPermission()) {
+            requestBluetoothPermissionIfNeeded()
+        }
+
         setContent {
             BluetoothchatTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    topBar = {
-                        Navbar(title = "BluetoothChat")
+                BluetoothChecker(
+                    contentWhenOn = {
+                        Scaffold(
+                            modifier = Modifier.fillMaxSize(),
+                            topBar = { Navbar(title = "BluetoothChat") },
+                            bottomBar = { BottomNavbar() }
+                        ) { innerPadding ->
+                            HomeScreen(
+                                name = "BluetoothChat",
+                                modifier = Modifier.padding(innerPadding)
+                            )
+                        }
                     },
-                    bottomBar = {
-                        BottomNavbar()
+                    contentWhenOff = {
+                        EnableBluetoothScreen()
                     }
-                ) { innerPadding ->
-                    HomeScreen(
-                        name = "BluetoothChat",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                )
             }
         }
     }
-}
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    BluetoothchatTheme {
-        Scaffold(
-            topBar = { Navbar(title = "BluetoothChat") },
-            bottomBar = { BottomNavbar() }
-        ) {
-            HomeScreen(name = "BluetoothChat", modifier = Modifier.padding(it))
+    private fun hasBluetoothConnectPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    private fun requestBluetoothPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            requestPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
         }
     }
 }

--- a/app/src/main/java/com/example/bluetooth_chat/bluetooth/BluetoothChecker.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/bluetooth/BluetoothChecker.kt
@@ -1,0 +1,49 @@
+package com.example.bluetooth_chat.bluetooth
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun BluetoothChecker(
+    contentWhenOn: @Composable () -> Unit,
+    contentWhenOff: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val bluetoothAdapter = remember {
+        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as android.bluetooth.BluetoothManager
+        bluetoothManager.adapter
+    }
+    var isBluetoothOn by remember {
+        mutableStateOf(bluetoothAdapter?.isEnabled == true)
+    }
+
+    DisposableEffect(Unit) {
+        val filter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                val state = intent?.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                isBluetoothOn = state == BluetoothAdapter.STATE_ON
+            }
+        }
+        context.registerReceiver(receiver, filter)
+        onDispose {
+            context.unregisterReceiver(receiver)
+        }
+    }
+
+    if (isBluetoothOn) {
+        contentWhenOn()
+    } else {
+        contentWhenOff()
+    }
+}

--- a/app/src/main/java/com/example/bluetooth_chat/ui/components/EnableBluetoothScreen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/components/EnableBluetoothScreen.kt
@@ -1,0 +1,38 @@
+package com.example.bluetooth_chat.ui.components
+
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EnableBluetoothScreen() {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = { Navbar(title = "BluetoothChat") },
+        bottomBar = { BottomNavbar() }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text("Please enable Bluetooth to continue.")
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = {
+                    context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
+                }) {
+                    Text("Turn On Bluetooth")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bluetooth_chat/ui/components/EnableBluetoothScreen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/components/EnableBluetoothScreen.kt
@@ -7,8 +7,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+import com.example.bluetooth_chat.ui.theme.Typography
+import androidx.compose.ui.text.style.TextAlign
 
 @Composable
 fun EnableBluetoothScreen() {
@@ -25,12 +31,36 @@ fun EnableBluetoothScreen() {
             contentAlignment = Alignment.Center
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Please enable Bluetooth to continue.")
+                Text(
+                    text = "Bluetooth is turned off",
+                    style = TextStyle(
+                        fontFamily = Typography.bodyLarge.fontFamily,
+                        fontWeight = FontWeight.ExtraBold,
+                        fontSize = 22.sp
+                    )
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Enable Bluetooth to start connecting with nearby devices for chat.",
+                    style = TextStyle(
+                        fontFamily = Typography.bodyLarge.fontFamily,
+                        fontWeight = FontWeight.Light,
+                        fontSize = 16.sp,
+                        textAlign = TextAlign.Center
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                )
                 Spacer(modifier = Modifier.height(16.dp))
-                Button(onClick = {
-                    context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
-                }) {
-                    Text("Turn On Bluetooth")
+                Button(
+                    onClick = {
+                        context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text(text = "Enable Bluetooth")
                 }
             }
         }

--- a/app/src/main/java/com/example/bluetooth_chat/ui/components/HomeScreen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/components/HomeScreen.kt
@@ -3,10 +3,13 @@ package com.example.bluetooth_chat.ui.components
 import android.content.Intent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.bluetooth_chat.BluetoothDevicesActivity
@@ -27,7 +30,11 @@ fun HomeScreen(name: String, modifier: Modifier = Modifier) {
         Button(onClick = {
             val intent = Intent(context, BluetoothDevicesActivity::class.java)
             context.startActivity(intent)
-        }) {
+        },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = Color.White
+            )) {
             Text("Go to Bluetooth Devices")
         }
     }

--- a/app/src/main/java/com/example/bluetooth_chat/ui/components/HomeScreen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/components/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.example.bluetooth_chat.ui.theme
+package com.example.bluetooth_chat.ui.components
 
 import android.content.Intent
 import androidx.compose.foundation.layout.*


### PR DESCRIPTION
Title: Add Bluetooth Status Handling UI and Close #8

Description:

This PR introduces UI components for handling Bluetooth status in the app:

Added EnableBluetoothScreen.kt
A composable screen that prompts the user to enable Bluetooth when it's turned off, with a direct link to Bluetooth settings.

Added BluetoothChecker.kt
A composable wrapper that observes the Bluetooth state in real-time and switches between contentWhenOn and contentWhenOff accordingly.

Updated Home Screen UI
Made slight design adjustments to the Home Screen.

Closes: #8 Home screen - Bluetooth turned off