### PR TITLE
Added bluetooth logic to the bluetooth devices screen closes issue #15

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,14 @@
     xmlns:tools="http://schemas.android.com/tools" >
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
-        android:usesPermissionFlags="neverForLocation"
-        tools:targetApi="s" />
+
+    <!-- For Android 12+ (API 31+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <!-- For pre-Android 12 -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/bluetooth_chat/ui/components/BluetoothDevicesScreen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/components/BluetoothDevicesScreen.kt
@@ -1,5 +1,15 @@
 package com.example.bluetooth_chat.ui.components
 
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.content.*
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -12,23 +22,28 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.bluetooth_chat.R
 
 @Composable
 fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val bluetoothAdapter = remember {
+        (context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter
+    }
+
     var searchQuery by remember { mutableStateOf("") }
-
-    val dummyDevices = listOf(
-        "Sam's iPhone", "Galaxy S10", "Emily's AirPods", "MacBook Pro", "Pixel 6a", "OnePlus Nord",
-        "Ford SYNC", "Bose SoundLink", "Xbox Controller", "JBL Flip 5", "Anya’s iPad",
-        "Tom’s Laptop", "Beats Studio", "Lenovo Tablet"
-    )
-
-    val filteredDevices = remember(searchQuery) {
-        if (searchQuery.isBlank()) dummyDevices
-        else dummyDevices.filter { it.contains(searchQuery, ignoreCase = true) }
+    val devices = remember { mutableStateListOf<BluetoothDevice>() }
+    val filteredDevices = remember(searchQuery, devices) {
+        if (searchQuery.isBlank()) devices
+        else devices.filter {
+            val nameOrAddress = it.name ?: it.address ?: ""
+            nameOrAddress.contains(searchQuery, ignoreCase = true)
+        }
     }
 
     val isDarkTheme = isSystemInDarkTheme()
@@ -39,6 +54,104 @@ fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
         backgroundColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.4f)
     )
 
+    fun hasBluetoothPermissions(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED &&
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED &&
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        } else {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val allGranted = permissions.values.all { it }
+        if (allGranted) {
+            Log.d("Bluetooth", "All permissions granted")
+        } else {
+            Log.d("Bluetooth", "Permissions denied: $permissions")
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (!hasBluetoothPermissions()) {
+            val requiredPermissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                arrayOf(
+                    Manifest.permission.BLUETOOTH_SCAN,
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                )
+            } else {
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+
+            permissionLauncher.launch(requiredPermissions)
+        }
+    }
+
+    val receiver = rememberUpdatedState(
+        object : BroadcastReceiver() {
+            override fun onReceive(c: Context?, intent: Intent?) {
+                if (BluetoothDevice.ACTION_FOUND == intent?.action) {
+                    val device: BluetoothDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+                    }
+
+                    if (device != null &&
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                                Manifest.permission.BLUETOOTH_CONNECT
+                            else
+                                Manifest.permission.BLUETOOTH
+                        ) == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        if (!devices.any { it.address == device.address }) {
+                            devices.add(device)
+                            Log.d("Bluetooth", "Device found: ${device.name ?: device.address}")
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    fun startDiscovery() {
+        if (hasBluetoothPermissions()) {
+            val filter = IntentFilter(BluetoothDevice.ACTION_FOUND)
+            context.registerReceiver(receiver.value, filter)
+
+            if (bluetoothAdapter?.isDiscovering == true) {
+                bluetoothAdapter.cancelDiscovery()
+            }
+
+            try {
+                bluetoothAdapter?.startDiscovery()
+            } catch (e: SecurityException) {
+                e.printStackTrace()
+            }
+        } else {
+            Log.d("Bluetooth", "Missing permissions to start discovery")
+        }
+    }
+
+    DisposableEffect(Unit) {
+        startDiscovery()
+
+        onDispose {
+            try {
+                context.unregisterReceiver(receiver.value)
+                bluetoothAdapter?.cancelDiscovery()
+            } catch (_: IllegalArgumentException) {
+            }
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -48,7 +161,7 @@ fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
-                label = { Text("Search for Bluetooth devices") },
+                label = { Text("Filter Bluetooth devices") },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 16.dp),
@@ -65,6 +178,21 @@ fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
             )
         }
 
+        Button(
+            onClick = {
+                startDiscovery()
+            },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = Color.White
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        ) {
+            Text("Scan for Devices")
+        }
+
         Text(
             text = "Available Devices",
             modifier = Modifier.padding(bottom = 16.dp),
@@ -79,7 +207,10 @@ fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(64.dp)
-                        .clickable { /* handle click */ },
+                        .clickable {
+                            val intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
+                            context.startActivity(intent)
+                        },
                     shape = MaterialTheme.shapes.medium,
                     tonalElevation = 2.dp,
                     color = MaterialTheme.colorScheme.surfaceVariant
@@ -98,7 +229,7 @@ fun BluetoothDevicesScreen(modifier: Modifier = Modifier) {
                                 .padding(end = 12.dp)
                         )
                         Text(
-                            text = device,
+                            text = device.name ?: device.address ?: "Unknown Device",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurface
                         )

--- a/app/src/main/java/com/example/bluetooth_chat/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/bluetooth_chat/ui/navigation/Screen.kt
@@ -1,8 +1,8 @@
 package com.example.bluetooth_chat.ui.navigation
 
 sealed class Screen(val route: String) {
-    object Home : Screen("home")
-    object Chat : Screen("chat")
-    object Groups : Screen("groups")
-    object BluetoothDevices : Screen("bluetooth_devices")
+    data object Home : Screen("home")
+    data object Chat : Screen("chat")
+    data object Groups : Screen("groups")
+    data object BluetoothDevices : Screen("bluetooth_devices")
 }


### PR DESCRIPTION
Changed bluetooth devices sreen file in order to allow for the app to scan for bluetooth devices instead of using mock data.

Modified Android Manifest in order to ask the user for bluetooth permissions when using the app

Slightly changed the design of the bluetooth devices screen with a button that manually scans for available devices

Closes #15 - Bluetooth device scanning